### PR TITLE
fix: issuance upon connection state response

### DIFF
--- a/agentLogic/contacts.js
+++ b/agentLogic/contacts.js
@@ -154,7 +154,7 @@ const adminMessage = async (connectionMessage) => {
         connectionMessage.error_msg,
       )
 
-      if (connectionMessage.state === 'active') {
+      if (connectionMessage.state === 'response') {
         let emailVerification = require('./emailVerification.js')
 
         await emailVerification.processRequests(

--- a/agentLogic/credentials.js
+++ b/agentLogic/credentials.js
@@ -176,7 +176,7 @@ const autoIssueCredential = async (
     if (!connection) {
       console.error('Connection Not Present')
       throw new ControllerError(2, 'Connection Not Present')
-    } else if (connection.state !== 'active') {
+    } else if (connection.state !== 'response') {
       console.error('Connection Not Ready to Receive Credentials')
       throw new ControllerError(3, 'Connection Not Active')
     }


### PR DESCRIPTION
Signed-off-by: Ammon Burgi <gitammonburgi@gmail.com>

# Summary of Changes

Changed the issuance to be called when connection state equals 'response' instead of 'active'.

# Related Issues

N/A

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ x ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [ ] Added **tests** for changed code (run `scripts/preflight` to run tests and check code style).
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ x ] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
